### PR TITLE
Fixed: Permission exception namespace.

### DIFF
--- a/Paysafe/Common/PermissionException.cs
+++ b/Paysafe/Common/PermissionException.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace optimal.common
+namespace Paysafe.Common
 {
     public class PermissionException : NetbanxException
     {


### PR DESCRIPTION
We tried out the SDK today and immediately got a null exception because this exception was in the wrong namespace.

This fix puts this exception in the correct namespace.