### PR TITLE
Update JSONObject.cs

### DIFF
--- a/Paysafe/Common/JSONObject.cs
+++ b/Paysafe/Common/JSONObject.cs
@@ -427,6 +427,10 @@ namespace Paysafe.Common
                         value[i] = this.cast(name, value[i], subType);
                         T = ((object)((System.Collections.IList)value)[i]).GetType();
                     }
+                    if (((System.Collections.IList)value).Count == 0)
+                    {
+                        T = subType;
+                    }
                     if (T != null && value is List<object>)
                     {
                         //convert list of subtype object to a list of the required subtype


### PR DESCRIPTION
Use CustomerVault.Profile to get a profile with address, cards, eftBankAccount and try to access the card object when there's no card associated with the profile and you get the following error : Cannot implicitly convert type 'System.Collections.Generic.List<object>' to 'System.Collections.Generic.List<Paysafe.CustomerVault.Card>'. 

This fix will set the card object to type Paysafe.CustomerVault.Card instead of Generic.List. Maybe there's a better way to fix it?